### PR TITLE
add tasks to 'cloudformer' namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,12 +8,12 @@ The list of rake tasks provided are:
 
 ```
 
-rake apply           # Apply Stack with Cloudformation script and parameters(And wait till complete - supports updates)
-rake delete          # Delete stack from CloudFormation(And wait till stack is complete)
-rake events          # Get the recent events from the stack
-rake outputs         # Get the outputs of stack
-rake recreate        # Recreate stack(runs delete & apply)
-rake status          # Get the deployed app status
+rake cloudformer:apply           # Apply Stack with Cloudformation script and parameters(And wait till complete - supports updates)
+rake cloudformer:delete          # Delete stack from CloudFormation(And wait till stack is complete)
+rake cloudformer:events          # Get the recent events from the stack
+rake cloudformer:outputs         # Get the outputs of stack
+rake cloudformer:recreate        # Recreate stack(runs delete & apply)
+rake cloudformer:status          # Get the deployed app status
 
 ```
 
@@ -120,12 +120,12 @@ Then, in your Rakefile add,
 
 You should then see following commands:
 
-    rake apply     # Apply Stack with Cloudformation script and parameters
-    rake delete    # Delete stack from CloudFormation
-    rake events    # Get the recent events from the stack
-    rake outputs   # Get the outputs of stack
-    rake recreate  # Recreate stack
-    rake status    # Get the deployed app status
+    rake cloudformer:apply     # Apply Stack with Cloudformation script and parameters
+    rake cloudformer:delete    # Delete stack from CloudFormation
+    rake cloudformer:events    # Get the recent events from the stack
+    rake cloudformer:outputs   # Get the outputs of stack
+    rake cloudformer:recreate  # Recreate stack
+    rake cloudformer:status    # Get the deployed app status
 
 Running `rake status` gives us:
 
@@ -133,7 +133,7 @@ Running `rake status` gives us:
       app - Not Deployed
     ================================================
 
-Running `rake apply` will create an environment or update existing depending on the nature of action requested in parameters:
+Running `rake cloudformer:apply` will create an environment or update existing depending on the nature of action requested in parameters:
 
     Initializing stack creation...
     ==================================================================================================
@@ -144,11 +144,11 @@ Running `rake apply` will create an environment or update existing depending on 
     2013-10-24 07:56:26 UTC - AWS::CloudFormation::Stack - CREATE_COMPLETE -
     ==================================================================================================
 
-Running `rake apply` again gives us:
+Running `rake cloudformer:apply` again gives us:
     
     No updates are to be performed.
 
-To remove the stack `rake delete` gives us:
+To remove the stack `rake cloudformer:delete` gives us:
 
     ==============================================================================================
     Attempting to delete stack - app
@@ -169,7 +169,7 @@ Attempts to delete a non-existing stack will result in:
     Stack not up.
     ==============================================
 
-To recreate the stack use `rake recreate`:
+To recreate the stack use `rake cloudformer:recreate`:
   
     =================================================================================================
     Attempting to delete stack - app
@@ -193,13 +193,13 @@ To recreate the stack use `rake recreate`:
     Server -  - 172.31.3.52
     =================================================================================================
 
-To see the stack outputs `rake outputs`:
+To see the stack outputs `rake cloudformer:outputs`:
     
     ==============================
     Server -  - 172.31.3.52
     ============================== 
 
-To see recent events on the stack `rake events`:
+To see recent events on the stack `rake cloudformer:events`:
     
     ==================================================================================================
     2013-10-24 08:06:31 UTC - AWS::CloudFormation::Stack - CREATE_IN_PROGRESS - User Initiated

--- a/lib/cloudformer/tasks.rb
+++ b/lib/cloudformer/tasks.rb
@@ -16,16 +16,18 @@ module Cloudformer
 
     private
     def define_tasks
-      define_create_task
-      define_validate_task
-      define_delete_task
-      define_delete_with_stop_task
-      define_events_task
-      define_status_task
-      define_outputs_task
-      define_recreate_task
-      define_stop_task
-      define_start_task
+      namespace :cloudformer do
+        define_create_task
+        define_validate_task
+        define_delete_task
+        define_delete_with_stop_task
+        define_events_task
+        define_status_task
+        define_outputs_task
+        define_recreate_task
+        define_stop_task
+        define_start_task
+      end
     end
 
     def define_create_task

--- a/lib/cloudformer/tasks.rb
+++ b/lib/cloudformer/tasks.rb
@@ -3,110 +3,110 @@ require 'cloudformer/stack'
 require 'rake/tasklib'
 
 module Cloudformer
- class Tasks < Rake::TaskLib
-   def initialize(stack_config)
-     @stack =Stack.new(stack_config)
-     if block_given?
-       yield self
-       define_tasks
-     end
-   end
+  class Tasks < Rake::TaskLib
+    def initialize(stack_config)
+      @stack =Stack.new(stack_config)
+      if block_given?
+        yield self
+        define_tasks
+      end
+    end
 
-   attr_accessor :template, :parameters, :disable_rollback, :retry_delete, :capabilities, :notify
+    attr_accessor :template, :parameters, :disable_rollback, :retry_delete, :capabilities, :notify
 
-   private
-   def define_tasks
-     define_create_task
-     define_validate_task
-     define_delete_task
-     define_delete_with_stop_task
-     define_events_task
-     define_status_task
-     define_outputs_task
-     define_recreate_task
-     define_stop_task
-     define_start_task
-   end
+    private
+    def define_tasks
+      define_create_task
+      define_validate_task
+      define_delete_task
+      define_delete_with_stop_task
+      define_events_task
+      define_status_task
+      define_outputs_task
+      define_recreate_task
+      define_stop_task
+      define_start_task
+    end
 
-   def define_create_task
-     desc "Apply Stack with Cloudformation script and parameters."
-     task :apply do
+    def define_create_task
+      desc "Apply Stack with Cloudformation script and parameters."
+      task :apply do
         if retry_delete
           @stack.delete
         end
         result = @stack.apply(template, parameters, disable_rollback, capabilities, notify)
         if result == :Failed then exit 1 end
         #if result == :NoUpdates then exit 2 end
-     end
-   end
-
-   def define_delete_task
-     desc "Delete stack from CloudFormation"
-     task :delete do
-      begin
-        exit 1 unless @stack.delete
-      rescue
-        puts "Stack deleted successfully."
       end
-     end
-   end
+    end
 
-   def define_delete_with_stop_task
-    desc "Delete stack after stopping all instances"
-    task :force_delete do
-      begin
+    def define_delete_task
+      desc "Delete stack from CloudFormation"
+      task :delete do
+        begin
+          exit 1 unless @stack.delete
+        rescue
+          puts "Stack deleted successfully."
+        end
+      end
+    end
+
+    def define_delete_with_stop_task
+      desc "Delete stack after stopping all instances"
+      task :force_delete do
+        begin
+          @stack.stop_instances
+          exit 1 unless @stack.delete
+        rescue => e
+          puts "Stack delete message - #{e.message}"
+        end
+      end
+    end
+
+    def define_status_task
+      desc "Get the deployed app status."
+      task :status do
+        @stack.status
+      end
+    end
+
+    def define_events_task
+      desc "Get the recent events from the stack."
+      task :events do
+        @stack.events
+      end
+    end
+
+    def define_outputs_task
+      desc "Get the outputs of stack."
+      task :outputs do
+        @stack.outputs
+      end
+    end
+    def define_recreate_task
+      desc "Recreate stack."
+      task :recreate => [:delete, :apply, :outputs]
+    end
+
+    def define_stop_task
+      desc "Stop EC2 instances in stack."
+      task :stop do
         @stack.stop_instances
-        exit 1 unless @stack.delete
-      rescue => e
-        puts "Stack delete message - #{e.message}"
       end
     end
-   end
 
-   def define_status_task
-     desc "Get the deployed app status."
-     task :status do
-      @stack.status
-     end
-   end
-
-   def define_events_task
-     desc "Get the recent events from the stack."
-     task :events do
-       @stack.events
-     end
-   end
-
-   def define_outputs_task
-     desc "Get the outputs of stack."
-     task :outputs do
-       @stack.outputs
-     end
-   end
-   def define_recreate_task
-     desc "Recreate stack."
-     task :recreate => [:delete, :apply, :outputs]
-   end
-
-   def define_stop_task
-    desc "Stop EC2 instances in stack."
-    task :stop do
-      @stack.stop_instances
+    def define_start_task
+      desc "Start EC2 instances in stack."
+      task :start do
+        @stack.start_instances
+      end
     end
-   end
 
-   def define_start_task
-    desc "Start EC2 instances in stack."
-    task :start do
-      @stack.start_instances
+    def define_validate_task
+      desc "Validate the Stack."
+      task :validate do
+        @stack.validate(template)
+      end
     end
-   end
-
-   def define_validate_task
-    desc "Validate the Stack."
-    task :validate do
-      @stack.validate(template)
-    end
-   end
- end
+  end
 end

--- a/lib/cloudformer/version.rb
+++ b/lib/cloudformer/version.rb
@@ -1,3 +1,3 @@
 module Cloudformer
-  VERSION = "0.0.14"
+  VERSION = "1.0.0"
 end


### PR DESCRIPTION
Tasks from gems, being at the root level will cause conflicts with consumers personal tasks or other gems that use the same names. Good practice to stick tasks behind a namespace.

I also bumped the major version as this causes breaking changes and consumer will need to change their scripts referencing the tasks to incorporate the namespace.